### PR TITLE
Fix streaming mode in standalone

### DIFF
--- a/src/superqComputation.cpp
+++ b/src/superqComputation.cpp
@@ -493,11 +493,11 @@ void SuperqComputation::run()
 
         yDebug()<<"[SuperqComputation]: points size "<<points.size();
 
+        if (one_shot==false)
+            getPoints3D();
+
         if (points.size()>0)
         {
-            if (one_shot==false)
-                getPoints3D();
-
             mutex.lock();
 
             if ((filter_points==true) && (points.size()>0))
@@ -621,33 +621,36 @@ void SuperqComputation::getPoints3D()
 /***********************************************************************/
 void SuperqComputation::savePoints(const string &namefile, const Vector &colors)
 {
-    ofstream fout;
-    stringstream ss;
-    ss << count_file;
-    string count_file_str=ss.str();
-    fout.open((homeContextPath+namefile+count_file_str+".off").c_str());
-
-    if (fout.is_open())
+    if (save_points)
     {
-        fout<<"COFF"<<endl;
-        fout<<points.size()<<" 0 0"<<endl;
-        fout<<endl;
-        for (size_t i=0; i<points.size(); i++)
+        ofstream fout;
+        stringstream ss;
+        ss<<count_file;
+        string count_file_str=ss.str();
+        fout.open((homeContextPath+namefile+count_file_str+".off").c_str());
+
+        if (fout.is_open())
         {
-            int r=points[i][3];
-            int g=points[i][4];
-            int b=points[i][5];
-            fout<<points[i].subVector(0,2).toString(3,3)<<" "<<r<<" "<<g<<" "<<b<<endl;
+            fout<<"COFF"<<endl;
+            fout<<points.size()<<" 0 0"<<endl;
+            fout<<endl;
+            for (size_t i=0; i<points.size(); i++)
+            {
+                int r=points[i][3];
+                int g=points[i][4];
+                int b=points[i][5];
+                fout<<points[i].subVector(0,2).toString(3,3)<<" "<<r<<" "<<g<<" "<<b<<endl;
+            }
+
+            fout<<endl;
         }
+        else
+            yError()<<"[SuperqComputation]: Some problems in opening output file!";
 
-        fout<<endl;
+        fout.close();
+
+        count_file++;
     }
-    else
-        yError()<<"[SuperqComputation]: Some problems in opening output file!";
-
-    fout.close();
-
-    count_file++;
 }
 
 /***********************************************************************/

--- a/src/superqModule.cpp
+++ b/src/superqModule.cpp
@@ -562,7 +562,7 @@ bool SuperqModule::close()
      if (!portSuperq.isClosed())
         portSuperq.close();
 
-    if (mode_online)
+    if (mode_online && visualization_on)
         GazeCtrl.close();
 
     return true;
@@ -725,7 +725,7 @@ bool SuperqModule::configViewer(ResourceFinder &rf)
         r=255; g=255; b=0;
     }
 
-    if (mode_online)
+    if (mode_online && visualization_on)
     {
         Property optionG;
         optionG.put("device","gazecontrollerclient");


### PR DESCRIPTION
Hi @giuliavezzani 

With the intention of evaluating the perk we might gain by adopting the analytical Jacobian, @fbottarel and I have been aiming lately to perform visual comparisons between the two superquadrics (finite-diff vs. analytical) using the new VTK viewer (#6).

However, we got stumbled upon trying to talk to `superquadric-model`, both in streaming and RPC mode as described in the [tutorial][1], in a system configuration where the module runs alone (i.e. no other superquadric-* run in parallel).

This PR serves to fix the streaming mode, at least for what we managed to see.

We might be missing some points that are not clear from the documentation, therefore your review and/or advices are welcome.

[1]: https://github.com/robotology/superquadric-model/tree/master/tutorial